### PR TITLE
refactor: change matchers to validate html roles

### DIFF
--- a/src/components/Header/__tests__/header.test.tsx
+++ b/src/components/Header/__tests__/header.test.tsx
@@ -9,7 +9,7 @@ describe('Header', () => {
   it('should render the nav bar and the logo', () => {
       setup(false);
       const homeLink = screen.getByRole('link', {name: 'Home'});
-      const postsLink = screen.getByText('Posts');
+      const postsLink = screen.getByRole('link', {name:'Posts'});
       const logo = screen.getByAltText('ig.news')
 
       expect(homeLink).toBeInTheDocument();
@@ -20,7 +20,7 @@ describe('Header', () => {
   describe('when user is not logged in', () => {
     it('should render the sign in button', () => {
       setup(false);
-      const signInButton = screen.getByText('Sign In With Github');
+      const signInButton = screen.getByRole('button', {name: 'Sign In With Github'});
 
       expect(signInButton).toBeInTheDocument();
     });
@@ -29,7 +29,7 @@ describe('Header', () => {
   describe('when user is logged in', () => {
     it("should render the user's github name", () => {
     setup(true);
-    const loggedInButton = screen.getByText('GH Username')
+    const loggedInButton = screen.getByRole('button', {name: 'GH Username'})
 
     expect(loggedInButton).toBeInTheDocument();
     })

--- a/src/components/signInButton/__tests__/loggedInButton.test.tsx
+++ b/src/components/signInButton/__tests__/loggedInButton.test.tsx
@@ -9,9 +9,9 @@ describe('LoggedInButton', () => {
   
   it('should render the logged user name on the button', () => {
     setup();
-    const gitHubUserName = screen.getByText('GH Username');
+    const loggedInButton = screen.getByRole('button', {name: 'GH Username'});
 
-    expect(gitHubUserName).toBeInTheDocument();
+    expect(loggedInButton).toBeInTheDocument();
   })
   it('should render a close icon', () => {
     setup();

--- a/src/components/signInButton/__tests__/notLoggedInButton.test.tsx
+++ b/src/components/signInButton/__tests__/notLoggedInButton.test.tsx
@@ -15,7 +15,7 @@ describe('NotLoggedInButton', () => {
   
   it('should render the Sign In message', () => {
     setup();
-    const buttonText = screen.getByText('Sign In With Github');
+    const buttonText = screen.getByRole('button', {name: 'Sign In With Github'});
 
     expect(buttonText).toBeInTheDocument();
   })

--- a/src/components/signInButton/__tests__/signInButton.test.tsx
+++ b/src/components/signInButton/__tests__/signInButton.test.tsx
@@ -10,7 +10,7 @@ describe("SignInButton", () => {
   describe("when the user is not logged in", () => {
     it("should render the SignIn button", () => {
       setup(false);
-      const signInText = screen.getByText("Sign In With Github");
+      const signInText = screen.getByRole("button", {name: 'Sign In With Github'});
 
       expect(signInText).toBeInTheDocument();
     });
@@ -18,7 +18,7 @@ describe("SignInButton", () => {
   describe("when the user is logged in", () => {
     it("should render the user's github name", () => {
       setup(true);
-      const userName = screen.getByText("GH Username");
+      const userName = screen.getByRole('button', {name: "GH Username"});
 
       expect(userName).toBeInTheDocument();
     });


### PR DESCRIPTION
Modified tests in order to validate the visual aspect of the components and it's html roles as well.